### PR TITLE
캐릭터 선택 화면 (Character Selection Screen)/ 채팅화면 (Chat Screen) 구현 

### DIFF
--- a/lib/controllers/chat_controller.dart
+++ b/lib/controllers/chat_controller.dart
@@ -1,0 +1,20 @@
+import 'package:get/get.dart';
+import '../models/message.dart';
+
+class ChatController extends GetxController {
+  var messages = <Message>[].obs; // 메시지 리스트
+  final messageInput = ''.obs; // 입력 중인 메시지
+
+  void sendMessage() {
+    if (messageInput.value.isNotEmpty) {
+      // 사용자 메시지 추가
+      messages.add(Message(content: messageInput.value, isUser: true));
+      messageInput.value = ''; // 입력창 초기화
+
+      // 시스템 응답 (예시)
+      Future.delayed(Duration(seconds: 1), () {
+        messages.add(Message(content: '안녕하세요! 무엇을 도와드릴까요?', isUser: false));
+      });
+    }
+  }
+}

--- a/lib/models/message.dart
+++ b/lib/models/message.dart
@@ -1,0 +1,6 @@
+class Message {
+  final String content;
+  final bool isUser;
+
+  Message({required this.content, required this.isUser});
+}

--- a/lib/views/chat_screen.dart
+++ b/lib/views/chat_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/chat_controller.dart';
+
+class ChatScreen extends StatelessWidget {
+  final ChatController chatController = Get.put(ChatController());
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('대화하기'),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          // 메시지 리스트
+          Expanded(
+            child: Obx(() {
+              return ListView.builder(
+                reverse: true,
+                itemCount: chatController.messages.length,
+                itemBuilder: (context, index) {
+                  final message = chatController.messages.reversed.toList()[index];
+                  return Align(
+                    alignment: message.isUser ? Alignment.centerRight : Alignment.centerLeft,
+                    child: Container(
+                      margin: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+                      padding: EdgeInsets.all(10),
+                      decoration: BoxDecoration(
+                        color: message.isUser ? Colors.blue : Colors.grey[300],
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Text(
+                        message.content,
+                        style: TextStyle(color: message.isUser ? Colors.white : Colors.black),
+                      ),
+                    ),
+                  );
+                },
+              );
+            }),
+          ),
+          // 입력창
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    onChanged: (value) => chatController.messageInput.value = value,
+                    decoration: InputDecoration(
+                      hintText: '메시지를 입력하세요...',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: Icon(Icons.send),
+                  onPressed: () {
+                    chatController.sendMessage();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## 📋 Description

-  대화하기 버튼 클릭 캐릭터 선택 화면으로 이동하도록 구현. (app_routes 수정)
- 캐릭터 선택 화면 구현 (character_selection_screen)
-- 캐릭터를 선택할 수 있는 그리드 레이아웃 구현.
-- 각 캐릭터 카드 클릭 시 해당 캐릭터 이름을 인수로 전달하며 채팅 화면으로 이동.

- 채팅 화면(Chat Screen)

-- 사용자가 메시지를 입력하고 전송할 수 있는 UI 구현.
-- 사용자의 메시지와 캐릭터의 응답 메시지를 구분하여 화면에 표시.
-- 메시지를 표시하는 ChatBubble 위젯 추가.

- 채팅 화면(Chat Screen) 및 캐릭터 선택 화면(Character Selection Screen) 구현
-- 캐릭터 선택 화면에서 각 캐릭터를 선택하면 채팅 화면으로 이동하도록 구현.
-- 채팅 화면은 입력된 메시지를 전송하고, 메시지를 UI로 표시할 수 있도록 구성.
-- 채팅 화면 관련 컨트롤러(ChatController)와 모델(Message) 추가
--- ChatController: 메시지 상태 관리(GetX 사용).
--- Message 모델: 메시지의 내용과 발신자 정보를 관리.

## 📸 ScreenShot

- 구현한 화면 캡쳐본
- 캐릭터 선택 화면 
<img width="407" alt="캐릭터 선택 화면" src="https://github.com/user-attachments/assets/44f627f5-2d10-4ed9-b7d9-e6c539c791a6" />

- 채팅화면 

## 💬 to Reviewers
<img width="405" alt="채팅화면" src="https://github.com/user-attachments/assets/34a97538-6fb7-4f75-8081-8a93eded8bb3" />

- 추가로 공유할 내용
1. 대화하기 버튼으로 화면 전환 시 버튼 색상 변경이 적용되지 않아, 추후 수정이 필요할 것 같습니다.
2. 현재 반응형 레이아웃으로 구현했으나, 공통적인 반응형 스타일을 맞추는 논의가 필요해 보입니다.

- 추가해야 할 기능들
--  서버 연결 
-- 캐릭터 선택화면 검색 기능 구현 